### PR TITLE
Dropped Python 3.9 support

### DIFF
--- a/.github/workflows/python-pr.yml
+++ b/.github/workflows/python-pr.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.14"]
+        python-version: ["3.10", "3.14"]
 
     steps:
       - uses: actions/checkout@v5
@@ -81,7 +81,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.14"]
+        python-version: ["3.10", "3.14"]
 
     steps:
       - uses: actions/checkout@v5
@@ -148,7 +148,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.14"]
+        python-version: ["3.10", "3.14"]
 
     steps:
       - uses: actions/checkout@v5
@@ -194,7 +194,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: "pip"
 
       - name: Install dependencies

--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v5
@@ -48,7 +48,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.14"]
+        python-version: ["3.10", "3.14"]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ classifiers = [
   "Topic :: Utilities",
   "Topic :: File Formats",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -54,7 +53,7 @@ classifiers = [
   "Operating System :: MacOS",
   "Framework :: Pytest",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   "click>=8.0.1",
   "tabulate>0.8.7",
@@ -185,7 +184,7 @@ docstring-code-format = true
 docstring-code-line-length = "dynamic"
 
 [tool.pyright]
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 pythonPlatform = "All"
 include = ["suricata_check", "tests"]
 exclude = ["**/__pycache__"]


### PR DESCRIPTION
## Summary

Python 3.9 has reached end-of-life. This PR bumps the minimum supported version to 3.10.

## Changes

- **pyproject.toml**: Update  from  to , remove  classifier, update  for pyright from  to 
- **CI workflows**: Update all matrix definitions to start from Python 3.10 instead of 3.9

## Verification

- All workflow matrix definitions consistently use 3.10 as the minimum
- No remaining references to Python 3.9 in configuration or CI files

Closes #50