### PR TITLE
feat: display number of suppressed issues in log output (closes #47)

### DIFF
--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -26,4 +26,4 @@ You can also use regular expressions to suppress issues:
 alert ip any any -> any any (msg:"Test"; sid:1; metadata: suricata-check "S800,S.*,C.*";)
 ```
 
-Ignoring issues for specific rules as described above will result in output without any of the suppressed issues for that rule. Therefore, these issues will not be present in `stdout`, `suricata-check.fast`, `suricata-check.jsonl` and not reflected in `suricata-check.stats`.
+Ignoring issues for specific rules as described above will result in output without any of the suppressed issues for that rule. Therefore, these issues will not be present in `stdout`, `suricata-check.fast`, or `suricata-check.jsonl`. However, the total count of suppressed issues is reported in `suricata-check.stats` and printed to `stdout` as a summary line after the total number of issues found.

--- a/suricata_check/_checkers.py
+++ b/suricata_check/_checkers.py
@@ -76,7 +76,10 @@ def get_checkers(
             checkers.append(checker(include=relevant_codes))
 
         else:
-            _logger.info("Checker %s is disabled.", checker.__name__)
+            _logger.info(
+                "Checker %s is disabled. Its issues are not counted towards suppressed issues.",
+                checker.__name__,
+            )
 
     _logger.info(
         "Discovered and enabled checkers: [%s]",

--- a/suricata_check/_checkers.py
+++ b/suricata_check/_checkers.py
@@ -77,7 +77,8 @@ def get_checkers(
 
         else:
             _logger.info(
-                "Checker %s is disabled. Its issues are not counted towards suppressed issues.",
+                "Checker %s is disabled.\
+Issues from this checker are not counted towards reported number of suppressed issues.",
                 checker.__name__,
             )
 

--- a/suricata_check/_output.py
+++ b/suricata_check/_output.py
@@ -159,6 +159,12 @@ def __write_output_stats(output: OutputReport, out: str) -> None:
             fg="blue",
         )
         click.secho(
+            f"Suppressed issues: {overall_summary['Suppressed Issues']}",
+            color=True,
+            bold=True,
+            fg="blue",
+        )
+        click.secho(
             f"Rules with Issues found: {overall_summary['Rules with Issues']}",
             color=True,
             bold=True,
@@ -349,6 +355,7 @@ def __get_overall_summary(
 ) -> SIMPLE_SUMMARY_TYPE:
     overall_summary = {
         "Total Issues": 0,
+        "Suppressed Issues": 0,
         "Rules with Issues": 0,
         "Rules without Issues": 0,
     }
@@ -357,6 +364,7 @@ def __get_overall_summary(
     for rule in rules:
         issues: ISSUES_TYPE = rule.issues
         overall_summary["Total Issues"] += len(issues)
+        overall_summary["Suppressed Issues"] += rule.suppressed_issues
 
         if len(issues) == 0:
             overall_summary["Rules without Issues"] += 1

--- a/suricata_check/_suricata_check.py
+++ b/suricata_check/_suricata_check.py
@@ -635,7 +635,7 @@ def analyze_rule(
                 unsuppressed = issues
                 for r in compiled_ignore:
                     unsuppressed = list(
-                        filter(lambda issue: r.match(issue.code) is None, unsuppressed)
+                        filter(lambda issue: r.match(issue.code) is None, unsuppressed),
                     )
                 rule_report.suppressed_issues += len(issues) - len(unsuppressed)
                 issues = unsuppressed

--- a/suricata_check/_suricata_check.py
+++ b/suricata_check/_suricata_check.py
@@ -631,8 +631,14 @@ def analyze_rule(
     for checker in checkers:
         try:
             issues = checker.check_rule(rule)
-            for r in compiled_ignore:
-                issues = list(filter(lambda issue: r.match(issue.code) is None, issues))
+            if compiled_ignore:
+                unsuppressed = issues
+                for r in compiled_ignore:
+                    unsuppressed = list(
+                        filter(lambda issue: r.match(issue.code) is None, unsuppressed)
+                    )
+                rule_report.suppressed_issues += len(issues) - len(unsuppressed)
+                issues = unsuppressed
             rule_report.add_issues(issues)
         except Exception as exception:  # noqa: BLE001
             _logger.warning(

--- a/suricata_check/utils/checker_typing.py
+++ b/suricata_check/utils/checker_typing.py
@@ -74,6 +74,7 @@ class RuleReport:
     summary: Optional[RULE_SUMMARY_TYPE] = None
     line_begin: Optional[int] = None
     line_end: Optional[int] = None
+    suppressed_issues: int = 0
 
     _issues: ISSUES_TYPE = field(default_factory=list, init=False)
 

--- a/tests/test_suricata_check.py
+++ b/tests/test_suricata_check.py
@@ -5,7 +5,7 @@ import sys
 import tarfile
 import urllib.request
 import warnings
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from typing import Callable
 
 import pytest
@@ -359,16 +359,16 @@ def test_main_ignore():
 
     __check_log_file()
     __check_fast_file([lambda line: "M001" not in line], [lambda file: "M000" in file])
+    __check_output(
+        result.output,
+        file_checks=[
+            lambda file: "Suppressed issues: " in file,
+            lambda file: "Suppressed issues: 0" not in file,
+        ],
+    )
 
     if result.exit_code != 0:
         pytest.fail(result.output)
-
-    # Assert that suppressed issues field is set and non-zero
-    assert "Suppressed issues:" in result.output
-    suppressed_line = [line for line in result.output.splitlines() if "Suppressed issues:" in line]
-    assert len(suppressed_line) > 0
-    suppressed_count = int(suppressed_line[0].split(":")[-1].strip())
-    assert suppressed_count > 0
 
 
 def test_get_ini_exclude_tuple():
@@ -433,7 +433,10 @@ def test_version():
         warnings.warn(RuntimeWarning("Version is unknown."))
 
 
-def __check_log_file(checks: Iterable[Callable[[str], bool]] = []):
+def __check_log_file(
+    line_checks: Sequence[Callable[[str], bool]] = [],
+    file_checks: Sequence[Callable[[str], bool]] = [],
+):
     log_file = "tests/data/out/suricata-check.log"
 
     if not os.path.exists(log_file):
@@ -447,11 +450,18 @@ def __check_log_file(checks: Iterable[Callable[[str], bool]] = []):
                 line,
             ):
                 pytest.fail(line)
-            for check in checks:
+            for check in line_checks:
                 if not check(line):
                     pytest.fail(line)
             if _regex_provider.match(r".+ - .+ - (WARNING) - .+", line):
                 warnings.warn(RuntimeWarning(line))
+
+    if len(file_checks) > 0:
+        with open(log_file) as log_fh:
+            file = "\n".join(log_fh.readlines())
+            for check in file_checks:
+                if not check(file):
+                    pytest.fail(file)
 
 
 def __check_fast_file(
@@ -477,6 +487,21 @@ def __check_fast_file(
             for check in file_checks:
                 if not check(file):
                     pytest.fail(file)
+
+
+def __check_output(
+    result: str,
+    line_checks: Sequence[Callable[[str], bool]] = [],
+    file_checks: Sequence[Callable[[str], bool]] = [],
+):
+    for line in result.split("\n"):
+        for check in line_checks:
+            if not check(line):
+                pytest.fail(line)
+
+    for check in file_checks:
+        if not check(result):
+            pytest.fail(result)
 
 
 def __main__():

--- a/tests/test_suricata_check.py
+++ b/tests/test_suricata_check.py
@@ -363,6 +363,13 @@ def test_main_ignore():
     if result.exit_code != 0:
         pytest.fail(result.output)
 
+    # Assert that suppressed issues field is set and non-zero
+    assert "Suppressed issues:" in result.output
+    suppressed_line = [line for line in result.output.splitlines() if "Suppressed issues:" in line]
+    assert len(suppressed_line) > 0
+    suppressed_count = int(suppressed_line[0].split(":")[-1].strip())
+    assert suppressed_count > 0
+
 
 def test_get_ini_exclude_tuple():
     ini = os.path.abspath(os.path.join("tests", "data", "suricata-check.ini"))


### PR DESCRIPTION
- Add suppressed_issues field to RuleReport to track per-rule suppressed count
- Count issues filtered by inline ignore patterns in analyze_rule
- Add 'Suppressed Issues' to overall_summary in stats
- Print suppressed issues count to stdout after total issues found
- Update docs/ignore.md to reflect new suppressed issues reporting behavior